### PR TITLE
Addtion ways to use colourscale

### DIFF
--- a/colourscale.m
+++ b/colourscale.m
@@ -164,30 +164,6 @@ rgb = rgb/255;
 
 
 %% Assign colours
-
-if do_apply_colours
-    for ii = 1:Nch
-      ind = mod(ii-1,Ncol)+1;
-      if isequal(get(ch(ii),'type'),'line')
-        if isempty(lw_range)
-          set(ch(permute(ii)),...
-            'Color',rgb(ind,:),...
-            'UserData','colourscale:ignore')
-        else
-          set(ch(permute(ii)),...
-            'Color',rgb(ind,:),...
-            'LineWidth',lw(ind),...
-            'UserData','colourscale:ignore')
-        end
-      end
-      if isequal(get(ch(ii),'type'),'surface')
-        set(ch(permute(ii)),...
-          'FaceColor',rgb(ind,:),...
-          'EdgeColor',rgb(ind,:),...
-          'UserData','colourscale:ignore')
-      end
-    end
-else
     for ii = 1:Nch
         ind = mod(ii-1,Ncol)+1;
         if isempty(lw_range)
@@ -200,6 +176,8 @@ else
                 'LineWidth',lw(ind),...
             };
         end
+    if do_apply_colours
+        set(ch(permute(ii)), lineprop{permute(ii),:});
     end
 end
 

--- a/colourscale.m
+++ b/colourscale.m
@@ -5,6 +5,14 @@ function [ RGBOUT, LINEPROPOUT ] = colourscale( varargin )
 %  to each "line". These colours are a spectrum of saturations and
 %  intensities for a given colour hue.
 %
+% COLOURSCALE(...,'ch',CH)
+%  Use CH to specify the mode of operation:
+%      CH is empty - apply colours to any lines present in the active axis 
+%                    except lines for which UserData = 'colourscale:ignore'
+%      CH is array of line handles - apply colours to specified lines 
+%      CH is an integer - generate CH number of colours (RBGOUT) and line 
+%                         properties (LINEPROPOUT) to be used later
+%
 % COLOURSCALE(...,'hue',H)
 %  Use hue H for colour scheme (default 20).
 %  H is a standard "HSV" hue, from 0 to 100, where approx.:
@@ -58,11 +66,15 @@ function [ RGBOUT, LINEPROPOUT ] = colourscale( varargin )
 %  indexing, such as in a four-plot graph:
 %      colourscale(...,'permute',[1 3 2 4])
 %
-% If the 'UserData' for a data line is 'colourscale:ignore', then
-% it will not be included in the COLOURSCALE colouring.
+% RGBOUT = COLOURSCALE(...)
+%  As above, and also returns the colours in a CH x 3 array.
 %
-% RGB = COLOURSCALE(...)
-%  As above, and also returns the colours in an array.
+% [RGBOUT,LINEPROPSOUT] = COLOURSCALE(...)
+%  As above, and also returns the line properties in a CH x 2 or CH x 4 
+%  cell array. Example:
+%      [RGBOUT,LINEPROPSOUT] = COLOURSCALE(...,'ch',2);
+%      plot(x1,y1,LINEPROPSOUT{1,:});
+%      plot(x2,y2,LINEPROPSOUT{2,:});
 
 
 %% COLOURSCALE  v0.1
@@ -164,18 +176,18 @@ rgb = rgb/255;
 
 
 %% Assign colours
-    for ii = 1:Nch
-        ind = mod(ii-1,Ncol)+1;
-        if isempty(lw_range)
-            lineprop(permute(ii),:) = {
-                'Color',rgb(ind,:),...
-            };
-        else
-            lineprop(permute(ii),:) = {
-                'Color',rgb(ind,:),...
-                'LineWidth',lw(ind),...
-            };
-        end
+for ii = 1:Nch
+    ind = mod(ii-1,Ncol)+1;
+    if isempty(lw_range)
+        lineprop(permute(ii),:) = {
+            'Color',rgb(ind,:),...
+        };
+    else
+        lineprop(permute(ii),:) = {
+            'Color',rgb(ind,:),...
+            'LineWidth',lw(ind),...
+        };
+    end
     if do_apply_colours
         set(ch(permute(ii)), lineprop{permute(ii),:});
     end

--- a/colourscale.m
+++ b/colourscale.m
@@ -79,14 +79,16 @@ function [ RGBOUT ] = colourscale( varargin )
 %% Option parsing
 
 p = inputParser;
-p.addOptional('hue',20);
-p.addOptional('chroma',70);
-p.addOptional('repeat',1);
-p.addOptional('permute',[]);
-p.addOptional('lumin',{[65 65] [50 80] [40 80] [30 90]});
-p.addOptional('linewidth',[]);
+p.addOptional('ch',findobj(gca,'Type','line','-not','UserData','colourscale:ignore'),@(x) all(isgraphics(x,'line')));
+p.addOptional('hue',20,@isnumeric);
+p.addOptional('chroma',70,@isnumeric);
+p.addOptional('repeat',1,@isnumeric);
+p.addOptional('permute',[],@isnumeric);
+p.addOptional('lumin',{[65 65] [50 80] [40 80] [30 90]},@(x) iscell(x) || isnumeric(x));
+p.addOptional('linewidth',[],@isnumeric);
 p.parse(varargin{:});
 
+ch       = p.Results.ch;
 hue      = p.Results.hue;
 chroma   = p.Results.chroma;
 Nseries  = p.Results.repeat;
@@ -106,8 +108,6 @@ end
 if isnumeric(lumin)
   lumin = {lumin};
 end
-
-ch = findobj(gca,'Type','line','-not','UserData','colourscale:ignore');
 
 Nch = numel(ch);
 Ncol = Nch/Nseries;


### PR DESCRIPTION
Should be completely backwards-compatible. I did remove support for surface plots in lines 175-180, however, I think it was impossible to reach this code anyway.